### PR TITLE
Fix bookmarks not saving when using add button

### DIFF
--- a/site/settings.ts
+++ b/site/settings.ts
@@ -392,7 +392,7 @@ export function renderBookmarkEditor(params: Record<string, string>) {
    const bookmark: Bookmark | undefined = params["source"]
       ? {
            source: (params["source"] + "/") as SourcePrefix,
-           label: params["feed"] ?? "",
+           label: "",
            ids: params["feed"] ? params["feed"].split("+") : [],
            isDefault: false,
         }


### PR DESCRIPTION
Hello! I recently came across this project and think it's really cool.

I noticed a small bug where using the "add" button to save a bookmark doesn't quite work.
It looks to be caused by `BookmarkEditor` expecting a new bookmark's `label` to be [empty](https://github.com/badlogic/ledit/blob/4b6e3fc8ea2dd208ae2a37a12d7d7fe502de71ce/site/settings.ts#L378).
Defaulting to an empty label regardless of the presence of `params["feed"]` seems to fix it.

Cheers!